### PR TITLE
Document command-line parameters a little more

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -246,3 +246,7 @@ paket-files/
 # JetBrains Rider
 .idea/
 *.sln.iml
+
+# HPV_Creator_Console builds
+HPV_Creator_Console/build/
+HPV_Creator_Console/output/

--- a/HPV_Creator_Console/README.md
+++ b/HPV_Creator_Console/README.md
@@ -32,11 +32,11 @@ cmake .. -G "MinGW Makefiles"
 mingw32-make
 ```
 
-Command-line parameters:
+## Command-line parameters:
 ```
 usage: ./HPVCreatorConsole --in=string --fps=int --type=int [options] ... 
 options:
-  -i, --in         in path (string)
+  -i, --in         in path (string) to image sequence directory
   -f, --fps        framerate (int)
   -t, --type       type (int)
   -s, --start      start frame (int [=0])
@@ -45,3 +45,8 @@ options:
   -n, --threads    num threads (int [=8])
   -?, --help       print this message
 ```
+The parameters above are mostly self-explanatory, but `type` is required and the argument should be an `int`, corresponding to the following compression types:
+
+* `0` = DXT1 (no alpha)
+* `1` = DTX5 (with alpha)
+* `2` = Scaled DXT5 (CoCg_Y)


### PR DESCRIPTION
While most of the parameters for the command-line tool are fairly self-exaplanatory, I have added a little bit of detail on the --input and --type parameters, since it wasn't immediately obvious how these should be used.

I have also excluded the build files for the command-line tool from the repo.